### PR TITLE
Fixes crash when attempting to send blank message

### DIFF
--- a/src/org/addhen/smssync/Util.java
+++ b/src/org/addhen/smssync/Util.java
@@ -571,9 +571,11 @@ public class Util {
      */
     public static void sendSms(String sendTo, String msg) {
 
-        SmsManager sms = SmsManager.getDefault();
-        ArrayList<String> parts = sms.divideMessage(msg);
-        sms.sendMultipartTextMessage(sendTo, null, parts, null, null);
+    	if (!msg.equals("")) {
+    		SmsManager sms = SmsManager.getDefault();
+    		ArrayList<String> parts = sms.divideMessage(msg);
+    		sms.sendMultipartTextMessage(sendTo, null, parts, null, null);
+    	}
     }
 
     /**


### PR DESCRIPTION
Sending a blank message causes the task checker to crash and stop polling
