### PR TITLE
Fix #345 - Save imported messages into the local database

### DIFF
--- a/smssync/src/main/java/org/addhen/smssync/data/database/MessageDatabaseHelper.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/database/MessageDatabaseHelper.java
@@ -277,6 +277,15 @@ public class MessageDatabaseHelper extends BaseDatabaseHelper {
         }
     }
 
+    public void putMessages(List<Message> messages) {
+        if (!isClosed()) {
+            try {
+                cupboard().withDatabase(getWritableDatabase()).put(messages);
+            } catch (Exception e) {
+            }
+        }
+    }
+
     public Integer deleteWithUuid(String uuid) {
         Integer row = 0;
         if (!isClosed()) {

--- a/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessage.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessage.java
@@ -20,7 +20,6 @@ package org.addhen.smssync.data.message;
 import org.addhen.smssync.R;
 import org.addhen.smssync.data.PrefsFactory;
 import org.addhen.smssync.data.cache.FileManager;
-import org.addhen.smssync.data.database.FilterDatabaseHelper;
 import org.addhen.smssync.data.entity.Message;
 import org.addhen.smssync.data.repository.datasource.filter.FilterDataSource;
 import org.addhen.smssync.data.repository.datasource.filter.FilterDataSourceFactory;
@@ -100,7 +99,7 @@ public abstract class ProcessMessage {
 
     public Message map(SmsMessage smsMessage) {
         Message message = new Message();
-        message._id = smsMessage.id;
+        message._id = null;
         message.messageUuid = smsMessage.uuid;
         message.messageBody = smsMessage.body;
         message.messageFrom = smsMessage.phone;

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/MessageDataRepository.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/MessageDataRepository.java
@@ -113,10 +113,12 @@ public class MessageDataRepository implements MessageRepository {
             ProcessSms processSms = mPostMessage.getProcessSms();
             List<SmsMessage> smsMessages = processSms.importMessages();
             List<Message> messages = new ArrayList<>();
+            mMessageDataSource = mMessageDataSourceFactory.createMessageDatabaseSource();
             for (SmsMessage smsMessage : smsMessages) {
                 messages.add(mPostMessage.map(smsMessage));
             }
-            return Observable.just(mMessageDataMapper.map(messages));
+            mMessageDataSource.putMessages(messages);
+            return Observable.just(syncFetchPending());
         });
     }
 

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDataSource.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDataSource.java
@@ -52,6 +52,8 @@ public interface MessageDataSource {
 
     void putMessage(Message message);
 
+    void putMessages(List<Message> messages);
+
     Integer deleteWithUuid(String uuid);
 
     Message fetchByUuid(String uuid);

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDatabaseSource.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDatabaseSource.java
@@ -98,6 +98,11 @@ public class MessageDatabaseSource implements MessageDataSource {
     }
 
     @Override
+    public void putMessages(List<Message> messages) {
+        mMessageDatabaseHelper.putMessages(messages);
+    }
+
+    @Override
     public Integer deleteWithUuid(String uuid) {
         return mMessageDatabaseHelper.deleteWithUuid(uuid);
     }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/view/ui/fragment/MessageFragment.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/view/ui/fragment/MessageFragment.java
@@ -278,9 +278,7 @@ public class MessageFragment extends BaseRecyclerViewFragment<MessageModel, Mess
         mImportMessagePresenter.setView(new ImportMessageView() {
             @Override
             public void showMessages(List<MessageModel> messageModelList) {
-                // Append the imported messages to the adapter list
                 if (!Utility.isEmpty(messageModelList)) {
-                    messageModelList.addAll(mMessageAdapter.getItems());
                     mMessageAdapter.setItems(messageModelList);
                     mFab.setVisibility(View.VISIBLE);
                     return;


### PR DESCRIPTION
Remove logic for appending the imported message to the message list.
Add method for saving the imported messages to the database then
reload pending messages from the database and populate it into the
incoming messages list