### PR TITLE
Fix #353 - Only send failed or unconfirmed messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0-beta2'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
         classpath 'me.tatarka:gradle-retrolambda:3.2.3'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'

--- a/dependencies/dependencies.gradle
+++ b/dependencies/dependencies.gradle
@@ -31,7 +31,7 @@ ext {
     //Libraries
     daggerVersion = '2.0.1'
     javaxAnnotationVersion = '1.0'
-    raiburariVersion = '2.7.0'
+    raiburariVersion = '2.8.0'
     cupboardVersion = '2.1.3'
     wakefulVersion = '1.0.5'
     okHttpVersion = '2.5.0'

--- a/smssync/build.gradle
+++ b/smssync/build.gradle
@@ -240,9 +240,7 @@ dependencies {
     def appTestDependencies = rootProject.ext.appTestDependencies
     apt appDependencies.daggerCompiler // Needed for source code generation
     compile fileTree(dir: 'libs', include: '*.jar')
-    compile(appDependencies.raiburari) {
-        exclude module: 'recyclerview-v7'
-    }
+    compile appDependencies.raiburari
     compile appDependencies.cupboard
     compile appDependencies.wakeful
     compile appDependencies.okHttp
@@ -250,10 +248,7 @@ dependencies {
     compile appDependencies.nineOldAndroids
     compile appDependencies.bottomSheet
     compile appDependencies.zXingQRCode
-    compile(appDependencies.supportPreference) {
-        exclude module: 'recyclerview-v7'
-    }
-    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile appDependencies.supportPreference
     provided appDependencies.javaxAnnotation // Needed to resolve compilation errors
 
     // Test depedencies

--- a/smssync/src/main/java/org/addhen/smssync/data/database/MessageDatabaseHelper.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/database/MessageDatabaseHelper.java
@@ -133,6 +133,20 @@ public class MessageDatabaseHelper extends BaseDatabaseHelper {
         return message;
     }
 
+    public Message fetchPendingMessageByUuid(String uuid) {
+        Message message = new Message();
+        final String whereClause = "message_uuid = ? AND status != ?";
+        try {
+            message = cupboard().withDatabase(getReadableDatabase()).query(Message.class)
+                    .withSelection(whereClause, uuid, Message.Status.SENT.name())
+                    .orderBy("messages_date DESC")
+                    .get();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return message;
+    }
+
     public Observable<List<Message>> fetchMessageByStatus(Message.Status status) {
         return Observable.create(subscriber -> {
             if (!isClosed()) {

--- a/smssync/src/main/java/org/addhen/smssync/data/entity/Message.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/entity/Message.java
@@ -79,6 +79,24 @@ public class Message extends DataEntity implements Serializable {
     @Column("status")
     public Status status;
 
+    @Override
+    public String toString() {
+        return "Message{"
+                + "messageBody='" + messageBody + '\''
+                + ", messageFrom='" + messageFrom + '\''
+                + ", messageDate=" + messageDate
+                + ", messageUuid='" + messageUuid + '\''
+                + ", messageType=" + messageType
+                + ", sentResultCode=" + sentResultCode
+                + ", sentResultMessage='" + sentResultMessage + '\''
+                + ", deliveryResultCode=" + deliveryResultCode
+                + ", deliveryResultMessage='" + deliveryResultMessage + '\''
+                + ", deliveredDate=" + deliveredDate
+                + ", retries=" + retries
+                + ", status=" + status
+                + '}';
+    }
+
     public enum Status {
         @SerializedName("unconfirmed")
         UNCONFIRMED,

--- a/smssync/src/main/java/org/addhen/smssync/data/message/PostMessage.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/PostMessage.java
@@ -167,12 +167,12 @@ public class PostMessage extends ProcessMessage {
         boolean status = false;
         // check if it should sync by id
         if (!TextUtils.isEmpty(uuid)) {
-            final Message message = mMessageDataSource.fetchMessageByUuid(uuid);
+            final Message message = mMessageDataSource.fetchPendingByUuid(uuid);
             List<Message> messages = new ArrayList<Message>();
             messages.add(message);
             status = postMessage(messages);
         } else {
-            final List<Message> messages = mMessageDataSource.fetchMessage(Message.Type.PENDING);
+            final List<Message> messages = mMessageDataSource.syncFetchPending();
             if (messages != null && messages.size() > 0) {
                 for (Message message : messages) {
                     status = postMessage(messages);

--- a/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessageResult.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessageResult.java
@@ -94,7 +94,7 @@ public class ProcessMessageResult {
             if ((response != null) && (response.isSuccess()) && (response.getUuids() != null)) {
                 final List<MessageResult> messageResults = new ArrayList<>();
                 for (String uuid : response.getUuids()) {
-                    Message message = mMessageDataSource.fetchMessageByUuid(uuid);
+                    Message message = mMessageDataSource.fetchPendingByUuid(uuid);
                     if (message != null) {
                         MessageResult messageResult = new MessageResult(message.messageUuid,
                                 message.sentResultCode, message.sentResultMessage,

--- a/smssync/src/main/java/org/addhen/smssync/data/message/TweetMessage.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/TweetMessage.java
@@ -146,13 +146,13 @@ public class TweetMessage extends ProcessMessage {
         boolean status = false;
         // check if it should sync by id
         if (!TextUtils.isEmpty(uuid)) {
-            final Message message = mMessageDataSource.fetchMessageByUuid(uuid);
+            final Message message = mMessageDataSource.fetchPendingByUuid(uuid);
             List<Message> messages = new ArrayList<Message>();
             messages.add(message);
             List<String> keywords = getKeywords();
             status = tweetMessages(messages);
         } else {
-            final List<Message> messages = mMessageDataSource.fetchMessage(Message.Type.PENDING);
+            final List<Message> messages = mMessageDataSource.syncFetchPending();
             if (messages != null && messages.size() > 0) {
                 for (Message message : messages) {
                     status = tweetMessages(messages);

--- a/smssync/src/main/java/org/addhen/smssync/data/net/BaseHttpClient.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/net/BaseHttpClient.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @author Ushahidi Team <team@ushahidi.com>
  */
-public class BaseHttpClient {
+public abstract class BaseHttpClient {
 
     private static final int TIME_OUT_CONNECTION = 30;
 

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/MessageDataRepository.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/MessageDataRepository.java
@@ -125,7 +125,7 @@ public class MessageDataRepository implements MessageRepository {
     @Override
     public MessageEntity syncFetchByUuid(String uuid) {
         mMessageDataSource = mMessageDataSourceFactory.createMessageDatabaseSource();
-        return mMessageDataMapper.map(mMessageDataSource.fetchMessageByUuid(uuid));
+        return mMessageDataMapper.map(mMessageDataSource.fetchPendingByUuid(uuid));
     }
 
 

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDataSource.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDataSource.java
@@ -58,5 +58,7 @@ public interface MessageDataSource {
 
     Message fetchByUuid(String uuid);
 
+    Message fetchPendingByUuid(String uuid);
+
     List<Message> syncFetchPending();
 }

--- a/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDatabaseSource.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/repository/datasource/message/MessageDatabaseSource.java
@@ -113,6 +113,11 @@ public class MessageDatabaseSource implements MessageDataSource {
     }
 
     @Override
+    public Message fetchPendingByUuid(String uuid) {
+        return mMessageDatabaseHelper.fetchPendingMessageByUuid(uuid);
+    }
+
+    @Override
     public List<Message> syncFetchPending() {
         return mMessageDatabaseHelper.syncFetchPending();
     }


### PR DESCRIPTION
This was causing duplication where failed messages in the pending
tray get reprocessed after they've been published
Upgrade Raiburari which has android support library update.