### PR TITLE
Don't close the `FileManager` on every write

### DIFF
--- a/smssync/src/main/java/org/addhen/smssync/data/message/PostMessage.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/PostMessage.java
@@ -280,7 +280,7 @@ public class PostMessage extends ProcessMessage {
                 msg.setMessageType(Message.Type.TASK);
                 if (response.getUuids().contains(msg.getMessageUuid())) {
                     sendTaskSms(msg);
-                    mFileManager.appendAndClose(mContext.getString(R.string.processed_task,
+                    mFileManager.append(mContext.getString(R.string.processed_task,
                             msg.getMessageBody()));
                 }
             }
@@ -378,13 +378,13 @@ public class PostMessage extends ProcessMessage {
                 messageHttpClient.execute();
                 gson = new Gson();
                 final String response = messageHttpClient.getResponse().body().string();
-                mFileManager.appendAndClose("HTTP Client Response: " + response);
+                mFileManager.append("HTTP Client Response: " + response);
                 smssyncResponses = gson.fromJson(response, SmssyncResponse.class);
             } catch (Exception e) {
                 Logger.log(TAG, "Task checking crashed " + e.getMessage() + " response: "
                         + messageHttpClient.getResponse());
                 try {
-                    mFileManager.appendAndClose(
+                    mFileManager.append(
                             "Task crashed: " + e.getMessage() + " response: " + messageHttpClient
                                     .getResponse().body().string());
                 } catch (IOException e1) {
@@ -394,7 +394,7 @@ public class PostMessage extends ProcessMessage {
 
             if (smssyncResponses != null) {
                 Logger.log(TAG, "TaskCheckResponse: " + smssyncResponses.toString());
-                mFileManager.appendAndClose("TaskCheckResponse: " + smssyncResponses.toString());
+                mFileManager.append("TaskCheckResponse: " + smssyncResponses.toString());
 
                 if (smssyncResponses.getPayload() != null) {
                     String task = smssyncResponses.getPayload().getTask();
@@ -424,7 +424,7 @@ public class PostMessage extends ProcessMessage {
                 }
             }
 
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     mContext.getString(R.string.finish_task_check) + " " + mErrorMessage + " for "
                             + syncUrl.getUrl());
         }

--- a/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessage.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessage.java
@@ -190,13 +190,13 @@ public abstract class ProcessMessage {
     }
 
     protected void logActivities(@StringRes int id) {
-        mFileManager.appendAndClose(mContext.getString(id));
+        mFileManager.append(mContext.getString(id));
     }
 
     protected void deleteFromSmsInbox(Message message) {
         if (mPrefsFactory.autoDelete().get()) {
             mProcessSms.delSmsFromInbox(map(message));
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     mContext.getString(R.string.auto_message_deleted, message.getMessageBody()));
         }
     }

--- a/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessageResult.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/message/ProcessMessageResult.java
@@ -128,7 +128,7 @@ public class ProcessMessageResult {
             try {
                 urlSecretEncoded = URLEncoder.encode(urlSecret, "UTF-8");
             } catch (java.io.UnsupportedEncodingException e) {
-                mFileManager.appendAndClose(e.getLocalizedMessage());
+                mFileManager.append(e.getLocalizedMessage());
             }
             newEndPointURL = newEndPointURL.concat(urlSecretEncoded);
         }
@@ -141,10 +141,10 @@ public class ProcessMessageResult {
             mAppHttpClient.setRequestBody(body);
             mAppHttpClient.execute();
         } catch (Exception e) {
-            mFileManager.appendAndClose(mContext.getString(R.string.message_processed_failed));
+            mFileManager.append(mContext.getString(R.string.message_processed_failed));
         } finally {
             if (200 == mAppHttpClient.getResponse().code()) {
-                mFileManager.appendAndClose(mContext.getString(R.string.message_processed_success));
+                mFileManager.append(mContext.getString(R.string.message_processed_success));
             }
         }
     }
@@ -171,24 +171,24 @@ public class ProcessMessageResult {
                 mAppHttpClient.execute();
             } catch (Exception e) {
                 e.printStackTrace();
-                mFileManager.appendAndClose("process crashed");
-                mFileManager.appendAndClose(mContext.getString(R.string.message_processed_failed));
-                mFileManager.appendAndClose(
+                mFileManager.append("process crashed");
+                mFileManager.append(mContext.getString(R.string.message_processed_failed));
+                mFileManager.append(
                         mContext.getString(R.string.message_processed_failed) + " " + e
                                 .getMessage());
             } finally {
                 if (200 == mAppHttpClient.getResponse().code()) {
 
-                    mFileManager.appendAndClose(
+                    mFileManager.append(
                             mContext.getString(R.string.message_processed_success));
                     response = parseMessagesUUIDSResponse(mAppHttpClient);
                     response.setSuccess(true);
-                    mFileManager.appendAndClose(
+                    mFileManager.append(
                             mContext.getString(R.string.message_processed_success));
 
                 } else {
                     response = new MessagesUUIDSResponse(mAppHttpClient.getResponse().code());
-                    mFileManager.appendAndClose(
+                    mFileManager.append(
                             mContext.getString(R.string.queued_messages_request_status,
                                     mAppHttpClient.getResponse().code(),
                                     mAppHttpClient.getResponse()));
@@ -217,7 +217,7 @@ public class ProcessMessageResult {
             try {
                 urlSecretEncoded = URLEncoder.encode(urlSecret, "UTF-8");
             } catch (java.io.UnsupportedEncodingException e) {
-                mFileManager.appendAndClose(e.getLocalizedMessage());
+                mFileManager.append(e.getLocalizedMessage());
             }
             newEndPointURL = newEndPointURL.concat(urlSecretEncoded);
         }
@@ -227,11 +227,11 @@ public class ProcessMessageResult {
             mAppHttpClient.setMethod(BaseHttpClient.HttpMethod.GET);
             mAppHttpClient.execute();
         } catch (JSONException e) {
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     mContext.getString(R.string.message_processed_json_failed) + " " + e
                             .getMessage());
         } catch (Exception e) {
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     mContext.getString(R.string.message_processed_failed) + " " + e.getMessage());
         } finally {
             if (200 == mAppHttpClient.getResponse().code()) {
@@ -239,7 +239,7 @@ public class ProcessMessageResult {
                 response.setSuccess(true);
             } else {
                 response = new MessagesUUIDSResponse(mAppHttpClient.getResponse().code());
-                mFileManager.appendAndClose(
+                mFileManager.append(
                         mContext.getString(R.string.messages_result_request_status,
                                 mAppHttpClient.getResponse().code(), mAppHttpClient.getResponse()));
             }
@@ -271,7 +271,7 @@ public class ProcessMessageResult {
         } catch (Exception e) {
             e.printStackTrace();
             response = new MessagesUUIDSResponse(client.getResponse().code());
-            mFileManager.appendAndClose(mContext.getString(R.string.message_processed_json_failed));
+            mFileManager.append(mContext.getString(R.string.message_processed_json_failed));
         }
         return response;
     }

--- a/smssync/src/main/java/org/addhen/smssync/data/net/MessageHttpClient.java
+++ b/smssync/src/main/java/org/addhen/smssync/data/net/MessageHttpClient.java
@@ -163,13 +163,13 @@ public class MessageHttpClient extends BaseHttpClient {
             case JSON:
                 body = RequestBody.create(JSON, DataFormatUtil.makeJSONString(getParams()));
                 log("setHttpEntity format JSON");
-                mFileManager.appendAndClose("setHttpEntity format JSON");
+                mFileManager.append("setHttpEntity format JSON");
                 break;
             case XML:
                 body = RequestBody.create(XML,
                         DataFormatUtil.makeXMLString(getParams(), "payload", UTF_8.name()));
                 log("setHttpEntity format XML");
-                mFileManager.appendAndClose(mContext.getString(R.string.http_entity_format, "XML"));
+                mFileManager.append(mContext.getString(R.string.http_entity_format, "XML"));
                 break;
             case URLEncoded:
                 log("setHttpEntity format URLEncoded");
@@ -178,12 +178,12 @@ public class MessageHttpClient extends BaseHttpClient {
                 for (HttpNameValuePair pair : params) {
                     formEncodingBuilder.add(pair.getName(), pair.getValue());
                 }
-                mFileManager.appendAndClose(
+                mFileManager.append(
                         mContext.getString(R.string.http_entity_format, "URLEncoded"));
                 body = formEncodingBuilder.build();
                 break;
             default:
-                mFileManager.appendAndClose(mContext.getString(R.string.invalid_data_format));
+                mFileManager.append(mContext.getString(R.string.invalid_data_format));
                 throw new Exception("Invalid data format");
         }
 
@@ -200,7 +200,7 @@ public class MessageHttpClient extends BaseHttpClient {
         Resources res = mContext.getResources();
         mClientError = String.format(Locale.getDefault(), "%s",
                 res.getString(R.string.sending_failed_custom_error, error));
-        mFileManager.appendAndClose(mClientError);
+        mFileManager.append(mClientError);
     }
 
     public String getServerError() {
@@ -213,7 +213,7 @@ public class MessageHttpClient extends BaseHttpClient {
         mServerError = String
                 .format(res.getString(R.string.sending_failed_custom_error, error),
                         res.getString(R.string.sending_failed_http_code, statusCode));
-        mFileManager.appendAndClose(mServerError);
+        mFileManager.append(mServerError);
     }
 
     public SmssyncResponse getServerSuccessResp() {

--- a/smssync/src/main/java/org/addhen/smssync/presentation/presenter/AlertPresenter.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/presenter/AlertPresenter.java
@@ -89,11 +89,11 @@ public class AlertPresenter {
                     mAppHttpClient.setMethod(BaseHttpClient.HttpMethod.POST);
                     mAppHttpClient.execute();
                 } catch (Exception e) {
-                    mFileManager.appendAndClose(e.getMessage());
+                    mFileManager.append(e.getMessage());
                 } finally {
                     if ((mAppHttpClient.getResponse()) != null && (200 == mAppHttpClient
                             .getResponse().code())) {
-                        mFileManager.appendAndClose(
+                        mFileManager.append(
                                 mContext.getResources()
                                         .getString(R.string.successful_alert_to_server));
                     }
@@ -125,11 +125,11 @@ public class AlertPresenter {
                 mAppHttpClient.setMethod(BaseHttpClient.HttpMethod.POST);
                 mAppHttpClient.execute();
             } catch (Exception e) {
-                mFileManager.appendAndClose(e.getMessage());
+                mFileManager.append(e.getMessage());
             } finally {
                 if (mAppHttpClient.getResponse() != null) {
                     if (200 == mAppHttpClient.getResponse().code()) {
-                        mFileManager.appendAndClose(mContext.getResources().getString(
+                        mFileManager.append(mContext.getResources().getString(
                                 R.string.successful_alert_to_server));
                     }
                 }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/presenter/DebugPresenter.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/presenter/DebugPresenter.java
@@ -74,7 +74,7 @@ public class DebugPresenter {
             try {
                 mAppHttpClient.execute();
             } catch (Exception e) {
-                mFileManager.appendAndClose(e.getMessage());
+                mFileManager.append(e.getMessage());
             }
 
             if (responseCode != 0) {

--- a/smssync/src/main/java/org/addhen/smssync/presentation/receiver/BootReceiver.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/receiver/BootReceiver.java
@@ -53,11 +53,11 @@ public class BootReceiver extends BroadcastReceiver {
         if (shutdown) {
             final long currentTime = System.currentTimeMillis();
             final String time = Utility.formatTimestamp(context, currentTime);
-            fileManager.appendAndClose(context.getString(R.string.device_shutdown, time));
+            fileManager.append(context.getString(R.string.device_shutdown, time));
         }
 
         if (rebooted) {
-            fileManager.appendAndClose(context.getString(R.string.device_reboot));
+            fileManager.append(context.getString(R.string.device_reboot));
             // Is SMSsync enabled
             if (prefsFactory.serviceEnabled().get()) {
 

--- a/smssync/src/main/java/org/addhen/smssync/presentation/receiver/ConnectivityChangedReceiver.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/receiver/ConnectivityChangedReceiver.java
@@ -78,6 +78,6 @@ public class ConnectivityChangedReceiver extends BroadcastReceiver {
             mAlertPresenter.lostConnectionThread.start();
         }
         App.getAppComponent().fileManager()
-                .appendAndClose(context.getString(R.string.no_data_connection));
+                .append(context.getString(R.string.no_data_connection));
     }
 }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/receiver/PowerStateChangedReceiver.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/receiver/PowerStateChangedReceiver.java
@@ -61,7 +61,7 @@ public class PowerStateChangedReceiver extends BroadcastReceiver {
         AlertPresenter alertPresenter = App.getAppComponent().alertPresenter();
         if (mBatteryLow) {
             // is smssync service enabled
-            fileManager.appendAndClose(context.getString(R.string.battery_low));
+            fileManager.append(context.getString(R.string.battery_low));
             if (prefsFactory.serviceEnabled().get()) {
                 Utility.clearAll(context);
                 // Stop the service that pushes pending messages
@@ -86,7 +86,7 @@ public class PowerStateChangedReceiver extends BroadcastReceiver {
         }
 
         if (batteryOkay) {
-            fileManager.appendAndClose(context.getString(R.string.battery_okay));
+            fileManager.append(context.getString(R.string.battery_okay));
             // is smssync enabled
             if (prefsFactory.serviceEnabled().get()) {
 

--- a/smssync/src/main/java/org/addhen/smssync/presentation/receiver/SmsDeliveredReceiver.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/receiver/SmsDeliveredReceiver.java
@@ -47,7 +47,7 @@ public class SmsDeliveredReceiver extends BroadcastReceiver {
                 resultMessage = context.getResources().getString(R.string.sms_delivered);
                 Toast.makeText(context, context.getResources().getString(R.string.sms_delivered),
                         Toast.LENGTH_LONG);
-                fileManager.appendAndClose(context.getResources().getString(
+                fileManager.append(context.getResources().getString(
                         R.string.sms_delivered));
                 break;
             case Activity.RESULT_CANCELED:
@@ -55,7 +55,7 @@ public class SmsDeliveredReceiver extends BroadcastReceiver {
                 Toast.makeText(context,
                         context.getResources().getString(R.string.sms_not_delivered),
                         Toast.LENGTH_LONG);
-                fileManager.appendAndClose(
+                fileManager.append(
                         context.getResources().getString(R.string.sms_not_delivered));
                 break;
         }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/receiver/SmsSentReceiver.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/receiver/SmsSentReceiver.java
@@ -134,6 +134,6 @@ public class SmsSentReceiver extends BroadcastReceiver {
 
     private void logActivities(String message) {
         FileManager fileManager = App.getAppComponent().fileManager();
-        fileManager.appendAndClose(message);
+        fileManager.append(message);
     }
 }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/CheckTaskService.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/CheckTaskService.java
@@ -71,6 +71,6 @@ public class CheckTaskService extends BaseWakefulIntentService {
             }
             return;
         }
-        mFileManager.appendAndClose(getString(R.string.no_data_connection));
+        mFileManager.append(getString(R.string.no_data_connection));
     }
 }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/MessageResultsService.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/MessageResultsService.java
@@ -50,7 +50,7 @@ public class MessageResultsService extends BaseWakefulIntentService {
     @Override
     public void executeTask(Intent intent) {
         log(getString(R.string.checking_scheduled_message));
-        mFileManager.appendAndClose(getString(R.string.checking_scheduled_message));
+        mFileManager.append(getString(R.string.checking_scheduled_message));
         mProcessMessageResult.processMessageResult();
     }
 }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/Scheduler.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/Scheduler.java
@@ -61,7 +61,7 @@ public class Scheduler {
     public void stopScheduler() {
         if (mAlarmManager != null && mPendingIntent != null) {
             Logger.log(CLASS_TAG, "Stop scheduler");
-            mFileManager.appendAndClose(mContext.getString(R.string.stopping_scheduler));
+            mFileManager.append(mContext.getString(R.string.stopping_scheduler));
             mAlarmManager.cancel(mPendingIntent);
         }
     }
@@ -75,7 +75,7 @@ public class Scheduler {
         Logger.log(CLASS_TAG, "updating scheduler");
         if (mAlarmManager != null && mPendingIntent != null) {
             Logger.log(CLASS_TAG, "Update scheduler to " + interval);
-            mFileManager.appendAndClose(mContext.getString(R.string.scheduler_updated_to));
+            mFileManager.append(mContext.getString(R.string.scheduler_updated_to));
             mAlarmManager.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
                     SystemClock.elapsedRealtime() + 60000, interval, mPendingIntent);
         }

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/ServiceControl.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/ServiceControl.java
@@ -118,7 +118,7 @@ public class ServiceControl {
             final Intent intent = new Intent(mContext,
                     MessageResultsScheduledReceiver.class);
             Logger.log(CLASS_TAG, "Message Results service started - interval: " + interval);
-            mFileManager.appendAndClose("Message Results service started - interval: " + interval);
+            mFileManager.append("Message Results service started - interval: " + interval);
             // run the service
             runServices(intent, ServiceConstants.MESSAGE_RESULTS_SCHEDULED_SERVICE_REQUEST_CODE,
                     interval);

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/SmsReceiverService.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/SmsReceiverService.java
@@ -279,7 +279,7 @@ public class SmsReceiverService extends Service implements HasComponent<AppServi
             }
             log("handleSmsReceived() messagesUuid: " + messagesUuid);
             // Log received SMS
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     getString(R.string.received_msg, msg.getMessageBody(), msg.getMessageFrom()));
 
             // Route the SMS
@@ -300,7 +300,7 @@ public class SmsReceiverService extends Service implements HasComponent<AppServi
         } else {
             Utility.showFailNotification(this, messagesBody,
                     getString(R.string.sending_succeeded));
-            mFileManager.appendAndClose(getString(R.string.sending_succeeded));
+            mFileManager.append(getString(R.string.sending_succeeded));
         }
         statusIntent.putExtra("sentstatus", 0);
         sendBroadcast(statusIntent);

--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/SyncPendingMessagesService.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/SyncPendingMessagesService.java
@@ -105,9 +105,9 @@ public class SyncPendingMessagesService extends BaseWakefulIntentService {
             if (!isWorking()) {
                 if (!SyncPendingMessagesService.isServiceWorking()) {
                     log("Sync started");
-                    mFileManager.appendAndClose(getString(R.string.sync_started));
+                    mFileManager.append(getString(R.string.sync_started));
                     // Log activity
-                    mFileManager.appendAndClose(getString(R.string.smssync_service_running));
+                    mFileManager.append(getString(R.string.smssync_service_running));
                     mState = new SyncPendingMessagesState(INITIAL, 0, 0, 0, 0, syncType, null);
                     try {
                         SyncConfig config = new SyncConfig(3, false, messageUuids, syncType);
@@ -116,7 +116,7 @@ public class SyncPendingMessagesService extends BaseWakefulIntentService {
                     } catch (Exception e) {
                         log("Not syncing " + e.getMessage());
                         mFileManager
-                                .appendAndClose(getString(R.string.not_syncing, e.getMessage()));
+                                .append(getString(R.string.not_syncing, e.getMessage()));
                         App.bus.post(mState.transition(ERROR, e));
                     }
                 } else {
@@ -148,7 +148,7 @@ public class SyncPendingMessagesService extends BaseWakefulIntentService {
             }
         } else {
             log(state.isCanceled() ? getString(R.string.canceled) : getString(R.string.done));
-            mFileManager.appendAndClose(
+            mFileManager.append(
                     (state.isCanceled() ? getString(R.string.canceled) : getString(R.string.done)));
             stopForeground(true);
             stopSelf();


### PR DESCRIPTION
Fix for #375 

As the `FileManager.append()` method calls `PrintWriter.println()`, messages will be flushed to file on every log write.  This may be inefficient.

I expect that the OS will close the file when the application shuts down.