### PR TITLE
Remove reference to HeadlessSmsSendService

### DIFF
--- a/smssync/src/main/AndroidManifest.xml
+++ b/smssync/src/main/AndroidManifest.xml
@@ -258,22 +258,6 @@
                 <data android:scheme="mmsto"/>
             </intent-filter>
         </activity>
-
-        <!-- Service that delivers messages from the phone "quick response" -->
-        <service
-                android:name=".HeadlessSmsSendService"
-                android:exported="true"
-                android:permission="android.permission.SEND_RESPOND_VIA_MESSAGE">
-            <intent-filter>
-                <action android:name="android.intent.action.RESPOND_VIA_MESSAGE"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-
-                <data android:scheme="sms"/>
-                <data android:scheme="smsto"/>
-                <data android:scheme="mms"/>
-                <data android:scheme="mmsto"/>
-            </intent-filter>
-        </service>
         <!-- End Android 4.4+ support-->
 
         <!-- connectivity changed -->


### PR DESCRIPTION
Issue: #393 

I don't think the `HeadlessSmsSendService` actually exists, so this PR removes the reference to it.