### PR TITLE
Remove 'gradle' requirement from build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,8 +6,6 @@ do so follow the steps below:
 1. Install the following software:
        - Android SDK:
          http://developer.android.com/sdk/index.html
-       - Gradle:
-         http://www.gradle.org/downloads
        - Android Studio - Optional: 
          http://developer.android.com/sdk/installing/studio.html
 


### PR DESCRIPTION
With the gradle wrapper, a separate gradle installation is not required.