### PR TITLE
Simplify implementation of State.isRunning()

### DIFF
--- a/smssync/src/main/java/org/addhen/smssync/presentation/task/state/State.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/task/state/State.java
@@ -52,7 +52,7 @@ public abstract class State {
     }
 
     public boolean isRunning() {
-        return EnumSet.of(SyncState.SYNC).contains(state);
+        return state == SyncState.SYNC;
     }
 
     public abstract State transition(SyncState newState, Exception exception);


### PR DESCRIPTION
No obvious reason to create a new `EnumSet` with one element each time this method is called.