### PR TITLE
Remove read phone state permission

### DIFF
--- a/smssync/src/main/AndroidManifest.xml
+++ b/smssync/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
-    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.CAMERA"/>


### PR DESCRIPTION
Fixes #415 

This `PR` makes the following changes:
- Remove `READ_PHONE_STATE` permission from the manifest. Not needed


