### PR TITLE
Add preference item to about section that links privacy notice

### DIFF
--- a/smssync/src/main/java/org/addhen/smssync/presentation/service/SyncPendingMessagesService.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/service/SyncPendingMessagesService.java
@@ -96,8 +96,10 @@ public class SyncPendingMessagesService extends BaseWakefulIntentService {
         if (intent != null) {
             final SyncType syncType = SyncType.fromIntent(intent);
             // Get Id
-            log("Get syncMessages messagesUuid: ");
-            messageUuids = intent.getStringArrayListExtra(ServiceConstants.MESSAGE_UUID);
+            if (intent.getFlags() == 100) {
+                log("Get syncMessages messagesUuid: ");
+                messageUuids = intent.getStringArrayListExtra(ServiceConstants.MESSAGE_UUID);
+            }
             Logger.log(CLASS_TAG, "SyncType: " + syncType);
             Logger.log(CLASS_TAG,
                     "doWakefulWork() executing this task with Flag " + intent.getFlags());

--- a/smssync/src/main/java/org/addhen/smssync/presentation/view/ui/fragment/AboutSettingsFragment.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/view/ui/fragment/AboutSettingsFragment.java
@@ -36,11 +36,15 @@ public class AboutSettingsFragment extends BasePreferenceFragmentCompat {
 
     private static final String KEY_TRANSLATE = "translate_preference";
 
+    private static final String KEY_PRIVACY = "privacy_preference";
+
     private static final String KEY_FORUMS = "forums_preference";
 
     private static final String KEY_GOOGLE_PLUS = "google_plus_preference";
 
     private static final String SMSSYNC_WEB_PAGE = "http://smssync.ushahidi.com";
+
+    private static final String PRIVACY_NOTICE_PAGE = "https://www.ushahidi.com/privacy";
 
     private static final String SMSSYNC_GOOGLE_PLUS_PAGE
             = "https://plus.google.com/communities/117573393008661621052";
@@ -66,6 +70,7 @@ public class AboutSettingsFragment extends BasePreferenceFragmentCompat {
         mAboutPreference.setTitle(getString(R.string.app_name));
         mAboutPreference.setSummary(getString(R.string.powered_by, mVersionLabel.toString()));
         launchSMSsyncWebsite();
+        launchPrivacy();
         launchTransifex();
         launchForums();
         launchGooglePlus();
@@ -80,6 +85,14 @@ public class AboutSettingsFragment extends BasePreferenceFragmentCompat {
         // When the about us item is clicked at the Settings screen, open a URL
         mAboutPreference.setOnPreferenceClickListener(preference -> {
             openUrl(SMSSYNC_WEB_PAGE);
+            return true;
+        });
+    }
+
+    private void launchPrivacy() {
+        Preference privacyPreference = findPreference(KEY_PRIVACY);
+        privacyPreference.setOnPreferenceClickListener(preference -> {
+            openUrl(PRIVACY_NOTICE_PAGE);
             return true;
         });
     }

--- a/smssync/src/main/res/values/strings.xml
+++ b/smssync/src/main/res/values/strings.xml
@@ -543,6 +543,11 @@
     <string name="google_plus_community_hint">Connect with us on our Google+ community page. Read
         about releases, share ideas or suggest improvements
     </string>
+    <string name="privacy_title">Privacy Notice</string>
+    <string name="privacy_hint">The following describes our policy for the information gathering,
+        use and dissemination practices of Ushahidi for the services provided through its various
+        websites and mobile apps.
+    </string>
     <string name="forums_title">SMSsync forum</string>
     <string name="forums_hint">Report issues or help someone with issues</string>
     <string name="about">About</string>

--- a/smssync/src/main/res/xml/about_preferences.xml
+++ b/smssync/src/main/res/xml/about_preferences.xml
@@ -21,6 +21,10 @@
             android:title="@string/about_smssync"
             android:key="about_preference"/>
     <Preference
+            android:title="@string/privacy_title"
+            android:summary="@string/privacy_hint"
+            android:key="privacy_preference"/>
+    <Preference
             android:title="@string/translate_title"
             android:summary="@string/translate_hint"
             android:key="translate_preference"/>


### PR DESCRIPTION
Fixes #470 

This `PR` makes the following changes:
- Adds preference item to about section that links privacy notice
- When tapped, it goes to https://www.ushahidi.com/privacy

Screenshot
<img src="https://cloud.githubusercontent.com/assets/73175/22917514/ab96a98e-f2c8-11e6-8b7b-902656987741.png" width="300" />
