### PR TITLE
473 add firebase crash reporting support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ android:
   - android-23
   - extra-android-support
   - extra-android-m2repository
+  - extra-google-google_play_services
+  - extra-google-m2repository
 
 # Exclude signing validation for product flavors
 script: ./gradlew clean build -x validateSigningInternalRelease -x validateSigningNoAnalyticsRelease -x validateSigningWithAnalyticsRelease

--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,11 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.0-beta3'
-        classpath 'me.tatarka:gradle-retrolambda:3.2.3'
+        classpath 'me.tatarka:gradle-retrolambda:3.5.0'
         classpath 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         classpath 'org.ajoberstar:gradle-git:1.6.0'
+        classpath 'com.google.gms:google-services:3.0.0'
     }
 
     // Exclude the version that the android plugin depends on.

--- a/dependencies/dependencies.gradle
+++ b/dependencies/dependencies.gradle
@@ -42,6 +42,7 @@ ext {
     zXingQRCodeVersion = '1.8.3'
     supportPreferenceVersion = '23.2.1'
     timberVersion = '4.5.1'
+    firebaseVersion = '10.0.1'
 
     //Testing
     jUnitVersion = '4.12'
@@ -66,6 +67,8 @@ ext {
             zXingQRCode        : "me.dm7.barcodescanner:zxing:${zXingQRCodeVersion}",
             supportPreference  : "com.android.support:preference-v7:${supportPreferenceVersion}",
             timber             : "com.jakewharton.timber:timber:${timberVersion}",
+            firebaseCore       : "com.google.firebase:firebase-core:${firebaseVersion}",
+            firebaseCrash      : "com.google.firebase:firebase-crash:${firebaseVersion}",
     ]
 
     appTestDependencies = [

--- a/smssync/build.gradle
+++ b/smssync/build.gradle
@@ -251,6 +251,9 @@ dependencies {
     compile appDependencies.zXingQRCode
     compile appDependencies.supportPreference
     compile appDependencies.timber
+    // Firebase(analytics, crash report)
+    compile appDependencies.firebaseCore
+    compile appDependencies.firebaseCrash
     provided appDependencies.javaxAnnotation // Needed to resolve compilation errors
 
     // Test depedencies
@@ -264,3 +267,6 @@ dependencies {
     androidTestCompile appTestDependencies.dexmakerMockito
     androidTestAnnotationProcessor appDependencies.daggerCompiler
 }
+
+// MUST BE AT THE BOTTOM
+apply plugin: 'com.google.gms.google-services'

--- a/smssync/google-services.json
+++ b/smssync/google-services.json
@@ -1,0 +1,135 @@
+{
+  "project_info": {
+    "project_number": "101482340714",
+    "firebase_url": "https://smssync-5b8f2.firebaseio.com",
+    "project_id": "smssync-5b8f2",
+    "storage_bucket": "smssync-5b8f2.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:101482340714:android:e85ac0bc14641c30",
+        "android_client_info": {
+          "package_name": "org.addhen.smssync"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "101482340714-4ac55sl39ridbfbgmfrnao7rcnb4u0d2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCq8W3PYWqYtAwFLaZAmD9RHvtDW6YVqKE"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:101482340714:android:60009a2109c34e65",
+        "android_client_info": {
+          "package_name": "org.addhen.smssync.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "101482340714-4ac55sl39ridbfbgmfrnao7rcnb4u0d2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCq8W3PYWqYtAwFLaZAmD9RHvtDW6YVqKE"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:101482340714:android:f49bf4e46dfcb48d",
+        "android_client_info": {
+          "package_name": "org.addhen.smssync.internal"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "101482340714-4ac55sl39ridbfbgmfrnao7rcnb4u0d2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCq8W3PYWqYtAwFLaZAmD9RHvtDW6YVqKE"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:101482340714:android:9b182fa62fd287ee",
+        "android_client_info": {
+          "package_name": "org.addhen.smssync.internal.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "101482340714-4ac55sl39ridbfbgmfrnao7rcnb4u0d2.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyCq8W3PYWqYtAwFLaZAmD9RHvtDW6YVqKE"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/smssync/src/main/java/org/addhen/smssync/presentation/App.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/App.java
@@ -53,7 +53,7 @@ public class App extends BaseApplication {
         super.onCreate();
         initializeInjector();
         mApp = this;
-        Timber.plant(new Timber.DebugTree());
+        Timber.plant(new FirebaseCrashTree());
     }
 
     private void initializeInjector() {

--- a/smssync/src/main/java/org/addhen/smssync/presentation/FirebaseCrashTree.java
+++ b/smssync/src/main/java/org/addhen/smssync/presentation/FirebaseCrashTree.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010 - 2017 Ushahidi Inc
+ * All rights reserved
+ * Contact: team@ushahidi.com
+ * Website: http://www.ushahidi.com
+ * GNU Lesser General Public License Usage
+ * This file may be used under the terms of the GNU Lesser
+ * General Public License version 3 as published by the Free Software
+ * Foundation and appearing in the file LICENSE.LGPL included in the
+ * packaging of this file. Please review the following information to
+ * ensure the GNU Lesser General Public License version 3 requirements
+ * will be met: http://www.gnu.org/licenses/lgpl.html.
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Ushahidi developers at team@ushahidi.com.
+ */
+
+package org.addhen.smssync.presentation;
+
+import com.google.firebase.crash.FirebaseCrash;
+
+import android.util.Log;
+
+import timber.log.Timber;
+
+/**
+ * A {@link Timber.Tree} that logs and sends crash reports to firebase's crash
+ * report console.
+ *
+ * @author Ushahidi Team <team@ushahidi.com>
+ */
+public class FirebaseCrashTree extends Timber.Tree {
+
+    @Override
+    protected void log(int priority, String tag, String message, Throwable t) {
+        if (priority == Log.VERBOSE || priority == Log.DEBUG) {
+            FirebaseCrash.log((priority == Log.DEBUG ? "[debug] " : "[verbose] ") + tag + ": "
+                    + message);
+            return;
+        }
+        FirebaseCrash.logcat(priority, tag, message);
+        if (t == null) {
+            return;
+        }
+
+        if (priority == Log.ERROR || priority == Log.WARN) {
+            FirebaseCrash.report(t);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #473 

This `PR` makes the following changes:
- Add firebase crash reporting support to Timber's logging

Todo

- [x] Switch `google-services.json` to one associated with Ushahidi's email address.

