### PR TITLE
(FIX) Check default SMS app before delete inbox sms

### DIFF
--- a/smssync/src/main/java/org/addhen/smssync/smslib/sms/ProcessSms.java
+++ b/smssync/src/main/java/org/addhen/smssync/smslib/sms/ProcessSms.java
@@ -17,11 +17,6 @@
 
 package org.addhen.smssync.smslib.sms;
 
-import org.addhen.smssync.presentation.model.MessageModel;
-import org.addhen.smssync.smslib.model.SmsMessage;
-import org.addhen.smssync.smslib.util.LogUtil;
-import org.addhen.smssync.smslib.util.Util;
-
 import android.annotation.SuppressLint;
 import android.app.PendingIntent;
 import android.content.ContentUris;
@@ -32,6 +27,12 @@ import android.database.DatabaseUtils;
 import android.net.Uri;
 import android.provider.Telephony;
 import android.telephony.SmsManager;
+
+import org.addhen.smssync.presentation.model.MessageModel;
+import org.addhen.smssync.presentation.util.Utility;
+import org.addhen.smssync.smslib.model.SmsMessage;
+import org.addhen.smssync.smslib.util.LogUtil;
+import org.addhen.smssync.smslib.util.Util;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -123,6 +124,11 @@ public class ProcessSms {
      * @return true if deleted otherwise false
      */
     public boolean delSmsFromInbox(MessageModel messageModel) {
+        if (!Utility.isDefaultSmsApp(mContext)) {
+            LogUtil.logDebug(CLASS_TAG, "delSmsFromInbox(): Failed as not default sms app");
+            return false;
+        }
+
         LogUtil.logInfo(CLASS_TAG, "delSmsFromInbox(): Delete SMS message app inbox");
         final long threadId = getThreadId(messageModel);
         if (threadId >= 0) {


### PR DESCRIPTION
On certain phones (e.g. Huawei Mate 8 running Nougat), if SMSSync is not the default SMS app, the app will crash when execute method **delSmsFromInbox()**. Below is the stack trace for this issue:

```
FATAL EXCEPTION: SmsReceiverService
Process: org.addhen.smssync.debug, PID: 11676
java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
    at android.database.CursorWindow.nativeGetLong(Native Method)
    at android.database.CursorWindow.getLong(CursorWindow.java:511)
    at android.database.AbstractWindowedCursor.getLong(AbstractWindowedCursor.java:90)
    at android.database.CursorWrapper.getLong(CursorWrapper.java:127)
    at org.addhen.smssync.smslib.sms.ProcessSms.getThreadIdKitKat(ProcessSms.java:273)
    at org.addhen.smssync.smslib.sms.ProcessSms.getThreadId(ProcessSms.java:237)
    at org.addhen.smssync.smslib.sms.ProcessSms.delSmsFromInbox(ProcessSms.java:127)
    at org.addhen.smssync.data.message.ProcessMessage.deleteFromSmsInbox(ProcessMessage.java:198)
    at org.addhen.smssync.data.message.PostMessage.routeSms(PostMessage.java:147)
    at org.addhen.smssync.presentation.service.SmsReceiverService.handleSmsReceived(SmsReceiverService.java:275)
    at org.addhen.smssync.presentation.service.SmsReceiverService$ServiceHandler.handleMessage(SmsReceiverService.java:339)
    at android.os.Handler.dispatchMessage(Handler.java:111)
    at android.os.Looper.loop(Looper.java:207)
    at android.os.HandlerThread.run(HandlerThread.java:61)
```
In order to void that, I propose to check the default SMS app before deleting inbox message

