### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,23 +37,16 @@ buildscript {
 
 allprojects {
     tasks.withType(Test).configureEach {
-        maxParallelForks = 4
-    }
-
-    tasks.withType(Test).configureEach {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        if (!project.hasProperty("createReports")) {
+            reports.html.required = false
+            reports.junitXml.required = false
+        }
         forkEvery = 100
     }
-
-    tasks.withType(Test).configureEach {
-        reports.html.required = false
-        reports.junitXml.required = false
-    }
-
     tasks.withType(JavaCompile).configureEach {
         options.incremental = true
     }
-
-
     repositories {
 
         jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,23 @@ buildscript {
 }
 
 allprojects {
+    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+    }
+
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+    tasks.withType(Test).configureEach {
+        reports.html.required = false
+        reports.junitXml.required = false
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.incremental = true
+    }
+
 
     repositories {
 


### PR DESCRIPTION
[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution). Gradle can run multiple test cases in parallel by setting `maxParallelForks`.

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation). We can conditionally disable it by setting `reports.html.required = false; reports.junitXml.required = false`. If you need to generate reports, add `-PcreateReports` to the end of Gradle's build command line.

[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.

[Incremental compilation](https://docs.gradle.org/current/userguide/performance.html#incremental_compilation). Gradle recompile only the classes that were affected by a change. This feature is the default since Gradle 4.10. For an older versions, we can activate it by setting `options.incremental = true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
